### PR TITLE
extend the process global using shim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,19 @@
       "name": "js-wasi-ext",
       "version": "1.0.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "process": "^0.11.10"
+      },
       "devDependencies": {
         "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "homepage": "https://github.com/fermyon/js-wasi-ext#readme",
   "devDependencies": {
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "process": "^0.11.10"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import process from "./process";
 
 export function setupExt() {
-	process.setupProcess();
+    process.insideHandler = true;
 }
-

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,24 +1,35 @@
 //@ts-ignore
 import { getEnvironment } from "wasi:cli/environment@0.2.0";
+//@ts-ignore
+import process from "process/browser"
 
-interface ProcessEnv {
-	[key: string]: string
+process.title = "starlingMonkey"
+
+if (delete process.env) {
+	Object.defineProperty(process, 'env', {
+		get: function () {
+			// if env does not exist populate the list if running within the handler
+			if (!this._env) {
+				// This needs to be set within the handler function 
+				if (!this.insideHandler) {
+					// return empty env for top level
+					return {}
+				}
+				this._env = {}
+				let env = getEnvironment();
+				env.map((k: any) => {
+					this._env[k[0] as string] = k[1] as string;
+				})
+			}
+			return this._env;
+		},
+		configurable: true,
+		enumerable: true,
+	});
 }
 
-class Process {
-	constructor() {
-		this.env = {}
-	}
-	setupProcess = () => {
-		let env = getEnvironment();
-		env.map((k: any) => {
-			this.env[k[0] as string] = k[1] as string;
-		})
-	}
-	env: ProcessEnv
-}
-
-const process = new Process();
+// We can probably support chdir if desierd (these throw errors in the upstream process shim).
+// If we do that, we probably want to fix cwd to properly represent the state as well. 
 
 export default process;
 


### PR DESCRIPTION
Populate env only if it is read by defining a custom getter that attempts to only populate if running inside the handler. This requires the `process.insideHandler` field to be set.

Instead of exporting a `setupExt` function, this now relies on a field being set on the process itself. This can be done from within the handler. 